### PR TITLE
Option to toggle placement warnings

### DIFF
--- a/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
+++ b/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import isaac.bastion.utils.BastionSettingManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -59,7 +60,11 @@ public final class BastionDamageListener implements Listener {
 			blockManager.erodeFromPlace(event.getPlayer(), blocking);
 			
 			event.setCancelled(true);
-			event.getPlayer().sendMessage(ChatColor.RED + "Bastion removed block");
+
+			BastionSettingManager settings = Bastion.getSettingManager();
+			if (!settings.getIgnorePlacementMessages(event.getPlayer().getUniqueId())) {
+				event.getPlayer().sendMessage(ChatColor.RED + "Bastion removed block");
+			}
 		}
 	}
 

--- a/src/main/java/isaac/bastion/listeners/BastionInteractListener.java
+++ b/src/main/java/isaac/bastion/listeners/BastionInteractListener.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.logging.Level;
 
+import isaac.bastion.utils.BastionSettingManager;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -156,7 +157,11 @@ public class BastionInteractListener implements Listener {
 
 			if (blocking.size() != 0 && !groupManager.canPlaceBlock(event.getPlayer(), blocking)){
 				event.setCancelled(true);
-				event.getPlayer().sendMessage(ChatColor.RED + "A Bastion prevents you from reinforcing");
+
+				BastionSettingManager settings = Bastion.getSettingManager();
+				if (!settings.getIgnorePlacementMessages(event.getPlayer().getUniqueId())) {
+					event.getPlayer().sendMessage(ChatColor.RED + "A Bastion prevents you from reinforcing");
+				}
 				return;
 			}
 		}

--- a/src/main/java/isaac/bastion/listeners/CitadelListener.java
+++ b/src/main/java/isaac/bastion/listeners/CitadelListener.java
@@ -3,6 +3,7 @@ package isaac.bastion.listeners;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import isaac.bastion.utils.BastionSettingManager;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -38,7 +39,11 @@ public class CitadelListener implements Listener {
 		}
 		if ((!blocking.isEmpty()) && !groupManager.canPlaceBlock(event.getPlayer(), blocking)){
 			event.setCancelled(true);
-			event.getPlayer().sendMessage(ChatColor.RED + "Bastion prevented reinforcement");
+
+			BastionSettingManager settings = Bastion.getSettingManager();
+			if (!settings.getIgnorePlacementMessages(event.getPlayer().getUniqueId())) {
+				event.getPlayer().sendMessage(ChatColor.RED + "Bastion prevented reinforcement");
+			}
 			blockManager.erodeFromPlace(event.getPlayer(), blocking);
 		}
 	}

--- a/src/main/java/isaac/bastion/utils/BastionSettingManager.java
+++ b/src/main/java/isaac/bastion/utils/BastionSettingManager.java
@@ -15,6 +15,7 @@ public class BastionSettingManager {
 	private BooleanSetting bsiOverlay;
 	private BooleanSetting showNoBastion;
 	private DisplayLocationSetting bsiLocation;
+	private BooleanSetting ignorePlacementWarnings;
 
 	public BastionSettingManager() {
 		initSettings();
@@ -27,10 +28,12 @@ public class BastionSettingManager {
 		showNoBastion = new BooleanSetting(Bastion.getPlugin(), false, "Display if you are not in a bastion field", "showNoBastion", "If enabled, will display Bastion status, even if you are not currently in a bastion field");
 
 		bsiLocation = new DisplayLocationSetting(Bastion.getPlugin(), DisplayLocationSetting.DisplayLocation.SIDEBAR, "BSI Location", "bsiLocation", new ItemStack(Material.ARROW), "Where to display BSI");
+		ignorePlacementWarnings = new BooleanSetting(Bastion.getPlugin(), false, "Ignore placement warnings", "ignorePlacementWarnings", "Show placements warning in chat when placing in a bastion field");
 
 		PlayerSettingAPI.registerSetting(bsiOverlay, menu);
 		PlayerSettingAPI.registerSetting(bsiLocation, menu);
 		PlayerSettingAPI.registerSetting(showNoBastion, menu);
+		PlayerSettingAPI.registerSetting(ignorePlacementWarnings, menu);
 	}
 
 	public BooleanSetting getBsiOverlay() {
@@ -43,5 +46,9 @@ public class BastionSettingManager {
 
 	public boolean getShowNoBastion(UUID uuid) {
 		return showNoBastion.getValue(uuid);
+	}
+
+	public boolean getIgnorePlacementMessages(UUID uuid) {
+		return ignorePlacementWarnings.getValue(uuid);
 	}
 }


### PR DESCRIPTION
Adds a per-player setting to toggle messages sent when placing/reinforcing blocks in hostile bastion fields.
This allows player to keep their chat tidy if they want to when breaking a bastion.
This does not apply to messages such as when pearling into a bastion field.