### PR TITLE
Add in unique elytra flight permission.

### DIFF
--- a/src/main/java/isaac/bastion/Bastion.java
+++ b/src/main/java/isaac/bastion/Bastion.java
@@ -158,6 +158,7 @@ public final class Bastion extends ACivMod {
 		PermissionType.registerPermission(Permissions.BASTION_PLACE, modAndAbove, "Allows a player to place blocks within a bastion field.", false);
 		PermissionType.registerPermission(Permissions.BASTION_LIST, modAndAbove, "Allows a player to see all bastions under this group.");
 		PermissionType.registerPermission(Permissions.BASTION_MANAGE_GROUPS, adminAndAbove, "Allows linking bastion groups.");
+		PermissionType.registerPermission(Permissions.BASTION_ELYTRA, modAndAbove, "Permits elytra flight through a bastion.");
 	}
 
 }

--- a/src/main/java/isaac/bastion/Permissions.java
+++ b/src/main/java/isaac/bastion/Permissions.java
@@ -9,4 +9,5 @@ public class Permissions {
 	public static final String BASTION_PLACE = "BASTION_PLACE";
 	public static final String BASTION_LIST = "BASTION_LIST";
 	public static final String BASTION_MANAGE_GROUPS = "BASTION_MANAGE_GROUPS";
+	public static final String BASTION_ELYTRA = "BASTION_ELYTRA";
 }

--- a/src/main/java/isaac/bastion/manager/ElytraManager.java
+++ b/src/main/java/isaac/bastion/manager/ElytraManager.java
@@ -3,6 +3,7 @@ package isaac.bastion.manager;
 import isaac.bastion.Bastion;
 import isaac.bastion.BastionBlock;
 import isaac.bastion.BastionType;
+import isaac.bastion.Permissions;
 import isaac.bastion.event.BastionDamageEvent;
 import isaac.bastion.event.BastionDamageEvent.Cause;
 import isaac.bastion.storage.BastionBlockStorage;
@@ -27,6 +28,8 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.Vector;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class ElytraManager {
 
@@ -204,8 +207,9 @@ public class ElytraManager {
 		for (BastionBlock bastion : possible) {
 			Location loc = bastion.getLocation().clone();
 			loc.setY(0);
-			
-			if (bastion.canPlace(player)) { // not blocked, continue
+
+			//check player flight permission.
+			if (NameAPI.getGroupManager().hasAccess(bastion.getGroup(), player.getUniqueId(), PermissionType.getPermission(Permissions.BASTION_ELYTRA))) {
 				continue;
 			}
 			if (bastion.getType().isSquare()) {


### PR DESCRIPTION
It's a bit rediculous that Elytra don't have their own permission. If you want people to be able to fly within your borders but not want place this makes it so that is possible.

Previously it was tied to the BASTION_PLACE permission. Now it is tied to its own unique BASTION_ELYTRA permission.

This will automatically be inherited by mods and above ranks. 